### PR TITLE
Fix corrupted script definitions

### DIFF
--- a/helper
+++ b/helper
@@ -1,4 +1,4 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 
 set +x
 
@@ -34,3 +34,4 @@ case $1 in
   *)
     echo "wrong argument";;
 esac
+

--- a/home/scripts/default.nix
+++ b/home/scripts/default.nix
@@ -14,3 +14,4 @@ let
     };
 in
 [ scripts ]
+

--- a/home/scripts/gen-ssh-key.nix
+++ b/home/scripts/gen-ssh-key.nix
@@ -1,12 +1,13 @@
-{ pkgs, ...}:
+{ pkgs, ... }:
 
 let
   add    = "${pkgs.openssh}/bin/ssh-add";
   agent  = "${pkgs.openssh}/bin/ssh-agent";
   keygen = "${pkgs.openssh}/bin/ssh-keygen";
 in
-  pkgs.writeShellScriptBin "gen-ssh-key" ''
-    ${keygen} -t ed25519 -C $1
-    eval $(${agent} -s)
-    ${add} $HOME/.ssh/id_ed25519
-  ''
+pkgs.writeShellScriptBin "gen-ssh-key" ''
+  ${keygen} -t ed25519 -C "$1"
+  eval "$(${agent} -s)"
+  ${add} "$HOME/.ssh/id_ed25519"
+''
+

--- a/home/scripts/keyboard-layout-switch.nix
+++ b/home/scripts/keyboard-layout-switch.nix
@@ -13,3 +13,4 @@ writeShellScriptBin "kls" ''
     ${xkbmap} -layout us
   fi
 ''
+

--- a/home/scripts/show-zombie-parents.nix
+++ b/home/scripts/show-zombie-parents.nix
@@ -1,5 +1,7 @@
 { pkgs, ... }:
 
 pkgs.writeShellScriptBin "show-zombie-parents" ''
-  ps -A -ostat,ppid | grep -e '[zZ]'| awk '{ print $2 }' | uniq | xargs ps -p
+  ps -A -ostat,ppid | grep -e '[zZ]' | awk '{ print $2 }' | uniq | xargs ps -p
 ''
+
+


### PR DESCRIPTION
## Summary
- restore helper script
- fix corrupted Nix script modules under `home/scripts`

## Testing
- `nix build .#homeConfigurations.hyprland.activationPackage` *(fails: `nix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407beba2e48325acfc70b28f874a07